### PR TITLE
Fix the parsing with pytest color output

### DIFF
--- a/src/fixture.ts
+++ b/src/fixture.ts
@@ -106,7 +106,7 @@ const parsePytestOutputToFixtures = (output: string, rootDir: string) => {
  */
 export const getFixtures = (document: vscode.TextDocument) => {
     let response;
-    const args = ["--fixtures", "-v", document.uri.fsPath];
+    const args = ["--color", "no", "--fixtures", "-v", document.uri.fsPath];
     const cwd = dirname(document.uri.fsPath);
     const pytestPath: string = vscode.workspace
         .getConfiguration("python.testing", document.uri)


### PR DESCRIPTION
Seems like the colourized output is not parsed properly, so the plugin fails to discover the fixtures.

This seems to fix the issue for me.

Running with `pytest 6.2.5`