### PR TITLE
new: add settings to enable/disable fixture loading on file change

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pytest-fixtures",
   "displayName": "pytest-fixtures",
   "description": "Pytest fixtures support for vscode",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "vscode": "^1.54.0"
   },
@@ -35,7 +35,18 @@
         "shortTitle": "Scan for pytest fixtures",
         "enablement": "resourceScheme == file && resourceLangId == python"
       }
-    ]
+    ],
+
+    "configuration": {
+      "title": "PyTest Fixtures",
+      "properties": {
+        "pytest-fixtures.scanForFixturesOnFileChange": {
+          "type": "boolean",
+          "default": true,
+          "description": "Scan current file for pytest fixtures on file change"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run package",


### PR DESCRIPTION
This pull request adds the option to enable auto scanning on file change.

Default value: `true`.    

![image](https://user-images.githubusercontent.com/953371/180723021-756b6b74-0e63-41f8-ae65-eca6eb8f725b.png)

Motivations
---
1. This  auto scanning feature slows down VSCode when using in conjunction with the auto discover on save
2. On large project it makes moving between files laggy and slows down the autocompletion and all VSCode code assistants.
3. It is very slow on multi-root workspaces (pytest's fault imho)

Due to these reasons, I think we should allow the users to disables the file based scanning.    
To make the extension usable without it too, this pull requests also recaches if file cache is empty on Go To Definitions


