### PR TITLE
Run for files that end with _test.py

### DIFF
--- a/src/suggestionProvider.ts
+++ b/src/suggestionProvider.ts
@@ -15,7 +15,7 @@ const isPythonTestFile = (document: vscode.TextDocument) => {
         return false;
     }
     const file = parse(document.fileName).base;
-    return file.startsWith("test_") || file.startsWith("conftest");
+    return file.startsWith("test_") || file.endsWith("_test.py") || file.startsWith("conftest");
 };
 
 /**


### PR DESCRIPTION
Allows running the extension for test files ending with `_test.py` rather than only those that start with `test_` or `conftest`, to more closely match the file name patterns supported by `pytest` (see [docs](https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html#test-discovery))

I tried to run tests locally and unfortunately could not get them passing, so I didn't look into writing a test for this case either. I'd happily accept some guidance on that point or on other preferences for contributions.

Resolves #22 