### PR TITLE
Fix multiline parsing

### DIFF
--- a/src/suggestionProvider.ts
+++ b/src/suggestionProvider.ts
@@ -31,7 +31,8 @@ const positionOfOpenParens = (document: vscode.TextDocument, position: vscode.Po
     let pos = position.translate(0, -1); // Check to the left of the cursor
     while (pos.line >= 0) {
         const line = document.lineAt(pos.line).text;
-        for (let character = line.length - 1; character >= 0; character--) {
+        const end = document.lineAt(pos).range.end.character;
+        for (let character = end; character >= 0; character--) {
             const char = line.substring(character, character + 1);
             if (char === "(") {
                 return new vscode.Position(pos.line, character);

--- a/src/suggestionProvider.ts
+++ b/src/suggestionProvider.ts
@@ -31,7 +31,7 @@ const positionOfOpenParens = (document: vscode.TextDocument, position: vscode.Po
     let pos = position.translate(0, -1); // Check to the left of the cursor
     while (pos.line >= 0) {
         const line = document.lineAt(pos.line).text;
-        for (let character = pos.character; character >= 0; character--) {
+        for (let character = line.length - 1; character >= 0; character--) {
             const char = line.substring(character, character + 1);
             if (char === "(") {
                 return new vscode.Position(pos.line, character);


### PR DESCRIPTION
This extension was not working properly in my environment and doing this fixed it for me. I'm not sure what the expected behavior from `line.character` was but it was not giving me the last character position. using `Position.range.end.character` fixed it for me.

However, I'm not sure yet how to deal with the failing tests in my environment. If you could give me some guidance then I would be more than happy to update this PR.